### PR TITLE
Add sdk support for lower devices.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId = "io.github.giangpham96"
-        minSdk = 23
+        minSdk = 19
         targetSdk = 32
         versionCode = 1
         versionName = "1.0"

--- a/expandabletextview/build.gradle.kts
+++ b/expandabletextview/build.gradle.kts
@@ -8,7 +8,7 @@ android {
     compileSdk = 32
 
     defaultConfig {
-        minSdk = 23
+        minSdk = 19
         targetSdk = 32
         consumerProguardFiles("consumer-proguard-rules.pro")
     }
@@ -45,4 +45,6 @@ afterEvaluate {
 
 dependencies {
     implementation("androidx.appcompat:appcompat:1.4.1")
+
+    implementation ("com.facebook.fbui.textlayoutbuilder:staticlayout-proxy:1.6.0")
 }

--- a/expandabletextview/src/main/java/io/github/giangpham96/expandabletextview/ExpandableTextView.kt
+++ b/expandabletextview/src/main/java/io/github/giangpham96/expandabletextview/ExpandableTextView.kt
@@ -21,7 +21,9 @@ import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import androidx.annotation.ColorInt
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.content.ContextCompat
+import androidx.core.text.TextDirectionHeuristicsCompat
 import androidx.interpolator.view.animation.FastOutSlowInInterpolator
+import com.facebook.fbui.textlayoutbuilder.proxy.StaticLayoutProxy
 import kotlin.math.abs
 
 class ExpandableTextView @JvmOverloads constructor(
@@ -240,13 +242,33 @@ class ExpandableTextView @JvmOverloads constructor(
 
     private fun getStaticLayout(targetMaxLines: Int, text: CharSequence, textWidth: Int): StaticLayout {
         val maximumLineWidth = textWidth.coerceAtLeast(0)
-        return StaticLayout.Builder
-            .obtain(text, 0, text.length, paint, maximumLineWidth)
-            .setIncludePad(false)
-            .setEllipsize(END)
-            .setMaxLines(targetMaxLines)
-            .setLineSpacing(lineSpacingExtra, lineSpacingMultiplier)
-            .build()
+        val alignment = ALIGN_NORMAL
+
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            StaticLayout.Builder
+                .obtain(text, 0, text.length, paint, maximumLineWidth)
+                .setIncludePad(false)
+                .setMaxLines(targetMaxLines)
+                .setAlignment(alignment)
+                .setEllipsize(END)
+                .setLineSpacing(lineSpacingExtra, lineSpacingMultiplier)
+                .build()
+        } else {
+            StaticLayoutProxy.create(
+                text,
+                0,
+                text.length,
+                paint,
+                maximumLineWidth,
+                alignment,
+                lineSpacingMultiplier,
+                lineSpacingExtra,
+                false,
+                END,
+                maximumLineWidth,
+                targetMaxLines,
+                TextDirectionHeuristicsCompat.FIRSTSTRONG_LTR)
+        }
     }
 
 }


### PR DESCRIPTION
I added sdk support for api 22 and lower devices.

I faced issue with Static Layout constructor because it is deprecated constructor not support for max lines parameter. It have a constructor but not accessing . I fix this issue it StaticLayoutProxy class from facebook TextLayoutBuilder library.

<img width="579" alt="Screen Shot 2022-12-18 at 21 31 40" src="https://user-images.githubusercontent.com/44908368/208313414-9bc33f90-5e80-455d-9527-416317d96bb3.png">
